### PR TITLE
Use inline placeholders for images

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
   <meta name="description" content="Learn about King Safari &amp; Car Hire, Tanzania's trusted provider for luxury vehicles and safari experiences.">
-  <link rel="icon" type="image/png" href="https://source.unsplash.com/32x32/?jeep">
+  <link rel="icon" type="image/png" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E">
   <style>
     body { font-family: 'Outfit', sans-serif; }
     .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; }

--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
   <meta name="description" content="Get in touch with King Safari. Phone numbers, email and WhatsApp chat for bookings across Tanzania.">
-  <link rel="icon" type="image/png" href="https://source.unsplash.com/32x32/?jeep">
+  <link rel="icon" type="image/png" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E">
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <style>

--- a/fleet.html
+++ b/fleet.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
   <meta name="description" content="Browse the King Safari fleet including VIP vans, rugged Land Cruisers and spacious minibuses.">
-  <link rel="icon" type="image/png" href="https://source.unsplash.com/32x32/?jeep">
+  <link rel="icon" type="image/png" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E">
   <style>
     body { font-family: 'Outfit', sans-serif; }
     .hover-scale:hover { transform: scale(1.03); transition: all 0.3s ease; }
@@ -36,21 +36,21 @@
     <h1 class="text-3xl font-semibold text-center mb-8">Our Fleet</h1>
     <div class="grid gap-6 md:grid-cols-3">
       <div class="shadow hover-scale">
-        <img src="https://source.unsplash.com/400x250/?van" alt="Toyota Alphard" class="w-full h-48 object-cover">
+        <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27250%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Toyota Alphard" class="w-full h-48 object-cover">
         <div class="p-4">
           <h2 class="font-semibold mb-2">Toyota Alphard (VIP)</h2>
           <p>Luxury comfort for executives and VIPs.</p>
         </div>
       </div>
       <div class="shadow hover-scale">
-        <img src="https://source.unsplash.com/400x250/?landcruiser" alt="Land Cruiser" class="w-full h-48 object-cover">
+        <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27250%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Land Cruiser" class="w-full h-48 object-cover">
         <div class="p-4">
           <h2 class="font-semibold mb-2">Land Cruiser (Safari)</h2>
           <p>Rugged 4x4 perfect for safari adventures.</p>
         </div>
       </div>
       <div class="shadow hover-scale">
-        <img src="https://source.unsplash.com/400x250/?minibus" alt="Coaster Minibus" class="w-full h-48 object-cover">
+        <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27250%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Coaster Minibus" class="w-full h-48 object-cover">
         <div class="p-4">
           <h2 class="font-semibold mb-2">Coaster Minibus (Groups)</h2>
           <p>Spacious option for large families or tour groups.</p>

--- a/gallery.html
+++ b/gallery.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
   <meta name="description" content="Explore photos from our recent safaris, vehicles and tours around Tanzania.">
-  <link rel="icon" type="image/png" href="https://source.unsplash.com/32x32/?jeep">
+  <link rel="icon" type="image/png" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E">
   <style>
     body { font-family: 'Outfit', sans-serif; }
     .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; }
@@ -35,14 +35,14 @@
     <h1 class="text-3xl font-semibold mb-8 text-center">Photo Gallery</h1>
     <p class="text-center mb-6">A collection of our safari adventures and vehicles.</p>
     <div class="grid gap-4 md:grid-cols-3">
-      <img src="https://source.unsplash.com/400x300/?safari" alt="Safari" class="w-full h-60 object-cover rounded">
-      <img src="https://source.unsplash.com/400x300/?jeep" alt="Jeep" class="w-full h-60 object-cover rounded">
-      <img src="https://source.unsplash.com/400x300/?animals" alt="Wildlife" class="w-full h-60 object-cover rounded">
-      <img src="https://source.unsplash.com/400x300/?travel" alt="Travel" class="w-full h-60 object-cover rounded">
-      <img src="https://source.unsplash.com/400x300/?minibus" alt="Minibus" class="w-full h-60 object-cover rounded">
-      <img src="https://source.unsplash.com/400x300/?sunset,safari" alt="Sunset" class="w-full h-60 object-cover rounded">
-      <img src="https://source.unsplash.com/400x300/?tanzania" alt="Tanzania" class="w-full h-60 object-cover rounded">
-      <img src="https://source.unsplash.com/400x300/?mount-kilimanjaro" alt="Kilimanjaro" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Safari" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Jeep" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Wildlife" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Travel" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Minibus" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Sunset" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Tanzania" class="w-full h-60 object-cover rounded">
+      <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27300%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Kilimanjaro" class="w-full h-60 object-cover rounded">
     </div>
   </div>
 </main>

--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   <meta name="description" content="Luxury Car Hire & Safari Services in Tanzania: Arusha, Moshi, Kilimanjaro & Dar. Book Toyota Alphard, Land Cruiser or Coaster now.">
   <meta property="og:title" content="King Safari & Car Hire">
   <meta property="og:description" content="Top-rated luxury safari and car rental services in Tanzania. Available in Arusha, Kilimanjaro, Moshi & Dar.">
-  <meta property="og:image" content="https://source.unsplash.com/1600x900/?safari,car">
+  <meta property="og:image" content="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%271600%27%20height%3D%27900%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E">
   <meta name="keywords" content="Tanzania car hire, safari cars Arusha, airport transfers Moshi, Kilimanjaro tours, Alphard rental, Land Cruiser Tanzania">
-  <link rel="icon" type="image/png" href="https://source.unsplash.com/32x32/?jeep">
+  <link rel="icon" type="image/png" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E">
   <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
   <style>
@@ -49,7 +49,7 @@
     </div>
   </div>
 </nav>
-<section id="home" class="h-screen flex items-center justify-center bg-cover bg-center" style="background-image: url('https://source.unsplash.com/1600x900/?safari');">
+<section id="home" class="h-screen flex items-center justify-center bg-cover bg-center" style="background-image: url('data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%271600%27%20height%3D%27900%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E');">
   <div class="text-center text-white px-4">
     <h1 class="text-4xl md:text-6xl font-bold mb-6 drop-shadow">Premium Safari & Car Hire</h1>
     <a href="#booking" class="bg-orange-500 hover:bg-orange-600 text-white py-3 px-8 rounded-full text-lg">Book Now</a>
@@ -129,21 +129,21 @@
     <h2 class="text-3xl font-semibold text-center mb-8">Our Fleet</h2>
     <div class="grid gap-6 md:grid-cols-3">
       <div class="shadow hover-scale">
-        <img src="https://source.unsplash.com/400x250/?van" alt="Toyota Alphard" class="w-full h-48 object-cover">
+        <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27250%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Toyota Alphard" class="w-full h-48 object-cover">
         <div class="p-4">
           <h3 class="font-semibold mb-2">Toyota Alphard (VIP)</h3>
           <p>Luxury comfort for executives and VIPs.</p>
         </div>
       </div>
       <div class="shadow hover-scale">
-        <img src="https://source.unsplash.com/400x250/?landcruiser" alt="Land Cruiser" class="w-full h-48 object-cover">
+        <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27250%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Land Cruiser" class="w-full h-48 object-cover">
         <div class="p-4">
           <h3 class="font-semibold mb-2">Land Cruiser (Safari)</h3>
           <p>Rugged 4x4 perfect for safari adventures.</p>
         </div>
       </div>
       <div class="shadow hover-scale">
-        <img src="https://source.unsplash.com/400x250/?minibus" alt="Coaster Minibus" class="w-full h-48 object-cover">
+        <img src="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%27400%27%20height%3D%27250%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E" alt="Coaster Minibus" class="w-full h-48 object-cover">
         <div class="p-4">
           <h3 class="font-semibold mb-2">Coaster Minibus (Groups)</h3>
           <p>Spacious option for large families or tour groups.</p>

--- a/terms.html
+++ b/terms.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
   <meta name="description" content="Review the rental terms and conditions for booking vehicles with King Safari.">
-  <link rel="icon" type="image/png" href="https://source.unsplash.com/32x32/?jeep">
+  <link rel="icon" type="image/png" href="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20width%3D%2732%27%20height%3D%2732%27%3E%3Crect%20width%3D%27100%25%27%20height%3D%27100%25%27%20fill%3D%27%2523EA580C%27/%3E%3C/svg%3E">
   <style>
     body { font-family: 'Outfit', sans-serif; }
     .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; }


### PR DESCRIPTION
## Summary
- replace external Unsplash links with inline image placeholders across pages
- ensure all HTML pages use local images for reliability

## Testing
- `python3 -m py_compile backend/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d5d1bfab88321a9e00516d8029259