### PR TITLE
Add Safari Surf WiFi site

### DIFF
--- a/docs/surfwifi/airport.html
+++ b/docs/surfwifi/airport.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Airport Pickup | Safari Surf WiFi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Outfit', sans-serif; }
+    .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; animation: pulse 2s infinite; }
+    @keyframes pulse {0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
+    .nav-blur{backdrop-filter:blur(10px);background-color:rgba(255,255,255,0.95);}    
+  </style>
+</head>
+<body class="bg-white text-gray-800 scroll-smooth antialiased">
+<nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+  <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+    <div class="hidden md:flex space-x-6 items-center">
+      <a href="plans.html" class="hover:text-orange-600">Plans</a>
+      <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+      <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+      <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+      <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </div>
+</nav>
+  <main class="pt-24 pb-16 container mx-auto px-4">
+    <h1 class="text-3xl font-bold mb-8 text-center">Airport Pickup Info</h1>
+    <div class="space-y-12">
+      <div>
+        <h2 class="text-xl font-semibold mb-2">JNIA – Dar es Salaam</h2>
+        <p>Terminal 3, Arrivals Hall</p>
+        <p>Staff available 24/7</p>
+      </div>
+      <div>
+        <h2 class="text-xl font-semibold mb-2">Zanzibar International Airport</h2>
+        <p>Kiosk near exit</p>
+        <p>Multilingual support</p>
+      </div>
+    </div>
+  </main>
+<footer class="bg-gray-900 text-gray-300 py-12">
+  <div class="container mx-auto px-4 text-center">
+    <div class="mb-6">
+      <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+      <a href="#" class="mx-2 hover:text-white">Terms</a>
+    </div>
+    <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+  </div>
+</footer>
+<a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/docs/surfwifi/booking.html
+++ b/docs/surfwifi/booking.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Online Booking | Safari Surf WiFi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Outfit', sans-serif; }
+    .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; animation: pulse 2s infinite; }
+    @keyframes pulse {0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
+    .nav-blur{backdrop-filter:blur(10px);background-color:rgba(255,255,255,0.95);}    
+  </style>
+</head>
+<body class="bg-white text-gray-800 scroll-smooth antialiased">
+<nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+  <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+    <div class="hidden md:flex space-x-6 items-center">
+      <a href="plans.html" class="hover:text-orange-600">Plans</a>
+      <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+      <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+      <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+      <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </div>
+</nav>
+  <main class="pt-24 pb-16 container mx-auto px-4">
+    <h1 class="text-3xl font-bold mb-8 text-center">Reserve Your Device</h1>
+    <form class="max-w-xl mx-auto space-y-4">
+      <div>
+        <label class="block mb-1 font-semibold" for="date">Pickup Date</label>
+        <input id="date" type="date" class="w-full border border-gray-300 px-3 py-2 rounded" />
+      </div>
+      <div>
+        <label class="block mb-1 font-semibold" for="airport">Airport</label>
+        <select id="airport" class="w-full border border-gray-300 px-3 py-2 rounded">
+          <option>JNIA</option>
+          <option>Zanzibar</option>
+        </select>
+      </div>
+      <div>
+        <label class="block mb-1 font-semibold" for="duration">Duration</label>
+        <select id="duration" class="w-full border border-gray-300 px-3 py-2 rounded">
+          <option>7 days</option>
+          <option>30 days</option>
+        </select>
+      </div>
+      <div>
+        <label class="block mb-1 font-semibold" for="name">Name</label>
+        <input id="name" type="text" class="w-full border border-gray-300 px-3 py-2 rounded" />
+      </div>
+      <div>
+        <label class="block mb-1 font-semibold" for="whatsapp">WhatsApp</label>
+        <input id="whatsapp" type="text" class="w-full border border-gray-300 px-3 py-2 rounded" />
+      </div>
+      <div class="text-center mt-6">
+        <button type="submit" class="bg-orange-600 text-white px-6 py-3 rounded hover:bg-orange-700">Submit</button>
+      </div>
+    </form>
+  </main>
+  <script>
+    document.querySelector('form').addEventListener('submit', function(e) {
+      e.preventDefault();
+      alert('Booking received!');
+    });
+  </script>
+<footer class="bg-gray-900 text-gray-300 py-12">
+  <div class="container mx-auto px-4 text-center">
+    <div class="mb-6">
+      <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+      <a href="#" class="mx-2 hover:text-white">Terms</a>
+    </div>
+    <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+  </div>
+</footer>
+<a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/docs/surfwifi/faqs.html
+++ b/docs/surfwifi/faqs.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FAQs | Safari Surf WiFi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Outfit', sans-serif; }
+    .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; animation: pulse 2s infinite; }
+    @keyframes pulse {0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
+    .nav-blur{backdrop-filter:blur(10px);background-color:rgba(255,255,255,0.95);}    
+  </style>
+</head>
+<body class="bg-white text-gray-800 scroll-smooth antialiased">
+<nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+  <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+    <div class="hidden md:flex space-x-6 items-center">
+      <a href="plans.html" class="hover:text-orange-600">Plans</a>
+      <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+      <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+      <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+      <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </div>
+</nav>
+  <main class="pt-24 pb-16 container mx-auto px-4">
+    <h1 class="text-3xl font-bold mb-8 text-center">FAQs</h1>
+    <div class="space-y-6 max-w-2xl mx-auto">
+      <div>
+        <h2 class="font-semibold">Can I pay in USD or TZS?</h2>
+        <p>Yes, we accept both currencies.</p>
+      </div>
+      <div>
+        <h2 class="font-semibold">Is there a data limit?</h2>
+        <p>No, all plans include unlimited data.</p>
+      </div>
+      <div>
+        <h2 class="font-semibold">What if I lose the device?</h2>
+        <p>Contact support immediately. Lost devices incur a replacement fee.</p>
+      </div>
+      <div>
+        <h2 class="font-semibold">How do I extend my plan?</h2>
+        <p>Send us a WhatsApp message or visit our booking page.</p>
+      </div>
+    </div>
+  </main>
+<footer class="bg-gray-900 text-gray-300 py-12">
+  <div class="container mx-auto px-4 text-center">
+    <div class="mb-6">
+      <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+      <a href="#" class="mx-2 hover:text-white">Terms</a>
+    </div>
+    <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+  </div>
+</footer>
+<a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/docs/surfwifi/footer.html
+++ b/docs/surfwifi/footer.html
@@ -1,0 +1,13 @@
+<footer class="bg-gray-900 text-gray-300 py-12">
+  <div class="container mx-auto px-4 text-center">
+    <div class="mb-6">
+      <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+      <a href="#" class="mx-2 hover:text-white">Terms</a>
+    </div>
+    <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+  </div>
+</footer>
+<a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>

--- a/docs/surfwifi/header.html
+++ b/docs/surfwifi/header.html
@@ -1,0 +1,12 @@
+<nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+  <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+    <div class="hidden md:flex space-x-6 items-center">
+      <a href="plans.html" class="hover:text-orange-600">Plans</a>
+      <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+      <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+      <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+      <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </div>
+</nav>

--- a/docs/surfwifi/how-it-works.html
+++ b/docs/surfwifi/how-it-works.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How It Works | Safari Surf WiFi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Outfit', sans-serif; }
+    .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; animation: pulse 2s infinite; }
+    @keyframes pulse {0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
+    .nav-blur{backdrop-filter:blur(10px);background-color:rgba(255,255,255,0.95);}    
+  </style>
+</head>
+<body class="bg-white text-gray-800 scroll-smooth antialiased">
+<nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+  <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+    <div class="hidden md:flex space-x-6 items-center">
+      <a href="plans.html" class="hover:text-orange-600">Plans</a>
+      <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+      <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+      <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+      <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </div>
+</nav>
+  <main class="pt-24 pb-16 container mx-auto px-4">
+    <h1 class="text-3xl font-bold mb-8 text-center">How It Works</h1>
+    <div class="grid gap-8 md:grid-cols-4 text-center">
+      <div>
+        <div class="text-5xl mb-2">1️⃣</div>
+        <p>Reserve online</p>
+      </div>
+      <div>
+        <div class="text-5xl mb-2">2️⃣</div>
+        <p>Pick up at airport kiosk</p>
+      </div>
+      <div>
+        <div class="text-5xl mb-2">3️⃣</div>
+        <p>Connect instantly</p>
+      </div>
+      <div>
+        <div class="text-5xl mb-2">4️⃣</div>
+        <p>Return at the same kiosk</p>
+      </div>
+    </div>
+    <div class="text-center mt-8">
+      <a href="booking.html" class="bg-orange-600 text-white px-6 py-3 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </main>
+<footer class="bg-gray-900 text-gray-300 py-12">
+  <div class="container mx-auto px-4 text-center">
+    <div class="mb-6">
+      <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+      <a href="#" class="mx-2 hover:text-white">Terms</a>
+    </div>
+    <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+  </div>
+</footer>
+<a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/docs/surfwifi/index.html
+++ b/docs/surfwifi/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Safari Surf WiFi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+  <meta name="description" content="Portable WiFi rental for tourists in Tanzania. Unlimited data with easy airport pickup and 24/7 support.">
+  <style>
+    body { font-family: 'Outfit', sans-serif; }
+    .floating-whatsapp {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background-color: #25D366;
+      color: white;
+      padding: 12px 16px;
+      border-radius: 50%;
+      font-size: 24px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+      z-index: 9999;
+      animation: pulse 2s infinite;
+    }
+    @keyframes pulse {
+      0% { transform: scale(1); }
+      50% { transform: scale(1.1); }
+      100% { transform: scale(1); }
+    }
+    .nav-blur { backdrop-filter: blur(10px); background-color: rgba(255,255,255,0.95); }
+    .testimonial { display: none; }
+    .testimonial.active { display: block; }
+  </style>
+</head>
+<body class="bg-white text-gray-800 scroll-smooth antialiased">
+  <nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+    <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+      <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+      <div class="hidden md:flex space-x-6 items-center">
+        <a href="plans.html" class="hover:text-orange-600">Plans</a>
+        <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+        <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+        <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+        <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="relative bg-cover bg-center h-screen" style="background-image: url('https://images.pexels.com/photos/221455/pexels-photo-221455.jpeg');">
+    <div class="absolute inset-0 bg-black opacity-40"></div>
+    <div class="relative z-10 flex items-center justify-center h-full">
+      <div class="text-center text-white px-4">
+        <h1 class="text-4xl md:text-6xl font-bold mb-6">Stay Connected Anywhere in Tanzania</h1>
+        <a href="booking.html" class="bg-orange-600 hover:bg-orange-700 text-white px-6 py-3 rounded text-lg">Reserve Your Device Now</a>
+      </div>
+    </div>
+  </header>
+
+  <section class="py-16 bg-gray-50">
+    <div class="container mx-auto px-4 text-center">
+      <h2 class="text-2xl font-bold mb-8">Why Safari Surf?</h2>
+      <div class="grid gap-8 md:grid-cols-4 text-left md:text-center">
+        <div>
+          <span class="text-4xl">✅</span>
+          <p class="mt-2">Unlimited High-Speed WiFi</p>
+        </div>
+        <div>
+          <span class="text-4xl">✅</span>
+          <p class="mt-2">Airport Pickup at JNIA & Zanzibar</p>
+        </div>
+        <div>
+          <span class="text-4xl">✅</span>
+          <p class="mt-2">No SIM Needed</p>
+        </div>
+        <div>
+          <span class="text-4xl">✅</span>
+          <p class="mt-2">24/7 WhatsApp Support</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16">
+    <div class="container mx-auto px-4">
+      <h2 class="text-2xl font-bold text-center mb-8">What Travelers Say</h2>
+      <div id="testimonialContainer">
+        <div class="testimonial active text-center">
+          <p class="italic max-w-2xl mx-auto">"The WiFi was fast and reliable throughout our safari adventure!"</p>
+          <p class="mt-2 font-semibold">– Emma, UK</p>
+        </div>
+        <div class="testimonial text-center">
+          <p class="italic max-w-2xl mx-auto">"Pickup at the airport was smooth and the device worked instantly."</p>
+          <p class="mt-2 font-semibold">– José, Spain</p>
+        </div>
+        <div class="testimonial text-center">
+          <p class="italic max-w-2xl mx-auto">"Great customer support on WhatsApp whenever we had questions."</p>
+          <p class="mt-2 font-semibold">– Aisha, UAE</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer class="bg-gray-900 text-gray-300 py-12">
+    <div class="container mx-auto px-4 text-center">
+      <div class="mb-6">
+        <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+        <a href="#" class="mx-2 hover:text-white">Terms</a>
+      </div>
+      <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+    </div>
+  </footer>
+
+  <a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+    let index = 0;
+    const testimonials = document.querySelectorAll('.testimonial');
+    setInterval(() => {
+      testimonials[index].classList.remove('active');
+      index = (index + 1) % testimonials.length;
+      testimonials[index].classList.add('active');
+    }, 5000);
+  </script>
+</body>
+</html>

--- a/docs/surfwifi/plans.html
+++ b/docs/surfwifi/plans.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Plans | Safari Surf WiFi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Outfit', sans-serif; }
+    .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; animation: pulse 2s infinite; }
+    @keyframes pulse {0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
+    .nav-blur{backdrop-filter:blur(10px);background-color:rgba(255,255,255,0.95);}    
+  </style>
+</head>
+<body class="bg-white text-gray-800 scroll-smooth antialiased">
+  <!-- Header -->
+<nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+  <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+    <div class="hidden md:flex space-x-6 items-center">
+      <a href="plans.html" class="hover:text-orange-600">Plans</a>
+      <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+      <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+      <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+      <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </div>
+</nav>
+  <!-- Main -->
+  <main class="pt-24 pb-16 container mx-auto px-4">
+    <h1 class="text-3xl font-bold mb-8 text-center">Plans</h1>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-center border border-gray-200">
+        <thead class="bg-gray-100">
+          <tr>
+            <th class="py-3 px-4">Plan</th>
+            <th class="py-3 px-4">Duration</th>
+            <th class="py-3 px-4">Price</th>
+            <th class="py-3 px-4">Ideal For</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr class="border-t">
+            <td class="py-3 px-4">Weekly WiFi</td>
+            <td class="py-3 px-4">7 days</td>
+            <td class="py-3 px-4">$100</td>
+            <td class="py-3 px-4">Short-term tourists</td>
+          </tr>
+          <tr class="border-t">
+            <td class="py-3 px-4">Monthly WiFi</td>
+            <td class="py-3 px-4">30 days</td>
+            <td class="py-3 px-4">$150</td>
+            <td class="py-3 px-4">Digital nomads/long stay</td>
+          </tr>
+          <tr class="border-t">
+            <td class="py-3 px-4">Refundable Deposit</td>
+            <td class="py-3 px-4">-</td>
+            <td class="py-3 px-4">$50</td>
+            <td class="py-3 px-4">All plans</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="mt-6 text-center">✅ All plans include unlimited data</p>
+    <p class="text-center">💳 Pay online or at pickup</p>
+  </main>
+<footer class="bg-gray-900 text-gray-300 py-12">
+  <div class="container mx-auto px-4 text-center">
+    <div class="mb-6">
+      <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+      <a href="#" class="mx-2 hover:text-white">Terms</a>
+    </div>
+    <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+  </div>
+</footer>
+<a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>

--- a/docs/surfwifi/support.html
+++ b/docs/surfwifi/support.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Customer Support | Safari Surf WiFi</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Outfit', sans-serif; }
+    .floating-whatsapp { position: fixed; bottom: 20px; right: 20px; background-color: #25D366; color: white; padding: 12px 16px; border-radius: 50%; font-size: 24px; box-shadow: 0 4px 12px rgba(0,0,0,0.2); z-index: 9999; animation: pulse 2s infinite; }
+    @keyframes pulse {0%{transform:scale(1);}50%{transform:scale(1.1);}100%{transform:scale(1);}}
+    .nav-blur{backdrop-filter:blur(10px);background-color:rgba(255,255,255,0.95);}    
+  </style>
+</head>
+<body class="bg-white text-gray-800 scroll-smooth antialiased">
+<nav class="nav-blur shadow fixed top-0 inset-x-0 z-50">
+  <div class="container mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="index.html" class="text-xl font-bold text-orange-600">Safari Surf WiFi</a>
+    <div class="hidden md:flex space-x-6 items-center">
+      <a href="plans.html" class="hover:text-orange-600">Plans</a>
+      <a href="how-it-works.html" class="hover:text-orange-600">How It Works</a>
+      <a href="airport.html" class="hover:text-orange-600">Airport Pickup</a>
+      <a href="faqs.html" class="hover:text-orange-600">FAQs</a>
+      <a href="booking.html" class="bg-orange-600 text-white px-4 py-2 rounded hover:bg-orange-700">Book Now</a>
+    </div>
+  </div>
+</nav>
+  <main class="pt-24 pb-16 container mx-auto px-4">
+    <h1 class="text-3xl font-bold mb-8 text-center">Customer Support</h1>
+    <p class="text-center mb-6">Chat live in English or Swahili 24/7.</p>
+    <div class="text-center space-x-4">
+      <a href="https://wa.me/255000000000" class="bg-green-500 text-white px-6 py-3 rounded hover:bg-green-600">WhatsApp</a>
+      <a href="tel:+255000000000" class="bg-orange-600 text-white px-6 py-3 rounded hover:bg-orange-700">Call Us</a>
+      <a href="mailto:info@safarisurfwifi.com" class="bg-gray-700 text-white px-6 py-3 rounded hover:bg-gray-800">Email</a>
+    </div>
+  </main>
+<footer class="bg-gray-900 text-gray-300 py-12">
+  <div class="container mx-auto px-4 text-center">
+    <div class="mb-6">
+      <a href="#" class="mx-2 hover:text-white">Privacy Policy</a>|
+      <a href="#" class="mx-2 hover:text-white">Terms</a>
+    </div>
+    <p>&copy; <span id="year"></span> Safari Surf WiFi. All rights reserved.</p>
+  </div>
+</footer>
+<a href="https://wa.me/255000000000" class="floating-whatsapp" title="Chat with us on WhatsApp" target="_blank" rel="noopener">💬</a>
+<script>
+  document.getElementById('year').textContent = new Date().getFullYear();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create new `docs/surfwifi` website folder
- add pages for homepage, plans, how it works, airport pickup info, FAQs, support, and booking
- share header/footer snippets for consistent layout

## Testing
- `python -m py_compile backend/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685e72f452c88321808fd73b21a74411